### PR TITLE
fix: avoid allocate memory

### DIFF
--- a/src/DemoContent.php
+++ b/src/DemoContent.php
@@ -106,6 +106,9 @@ class DemoContent {
     });
     foreach ($modules as $module) {
       $this->moduleInstaller->uninstall([$module]);
+      // Avoid memory allocate.
+      // phpcs:ignore
+      \Drupal\Component\FileCache\FileCache::reset();
     }
   }
 

--- a/src/DemoContent.php
+++ b/src/DemoContent.php
@@ -89,6 +89,9 @@ class DemoContent {
     $modules = array_keys($this->mapping) ?? [];
     foreach ($modules as $module) {
       $this->moduleInstaller->install([$module]);
+      // Avoid memory allocate.
+      // phpcs:ignore
+      \Drupal\Component\FileCache\FileCache::reset();
     }
   }
 


### PR DESCRIPTION
https://www.drupal.org/project/drupal/issues/3356739#comment-15223441

Drupal core have unlimited memory usege for files cache for now

<img width="1023" alt="Screenshot 2023-09-26 at 15 18 00" src="https://github.com/YCloudYUSAFree/ymca_cloud_infra/assets/26228931/37a0130f-cd83-41e7-9b40-6d5b8d1ba8b6">
